### PR TITLE
Upgrade Flutter to 3.41.5 for iOS 26

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,12 +32,12 @@ if (prodKeystoreFile.exists()) {
 
 android {
     namespace "com.mirrortv.mnews"
-    compileSdkVersion 35
+    compileSdkVersion 36
 
     defaultConfig {
         applicationId "com.mirrortv.mnews"
         minSdk 24
-        targetSdk 35
+        targetSdk 36
         versionCode flutterVersionCodeStr.toInteger()
         versionName flutterVersionName
         multiDexEnabled true
@@ -104,16 +104,6 @@ android {
             shrinkResources true
             minifyEnabled true
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
-        }
-    }
-
-    // ✅ 正確的 abi 設定（替代 ndk { abiFilters }）
-    splits {
-        abi {
-            enable true
-            reset()
-            include "armeabi-v7a", "arm64-v8a"
-            universalApk false
         }
     }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,6 +3,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
+kotlin.incremental=false
 
 # 16KB
 android.enableR8.fullMode=true


### PR DESCRIPTION
## Summary
- upgrade Flutter/FVM config to 3.41.5 and refresh Dart/pub lockfiles
- migrate iOS project for Xcode 26 / iOS 26 readiness, including UIScene changes and iOS 15 deployment target alignment
- fix Android CI issues for Flutter 3.41 by removing ABI split conflicts, bumping compile/target SDK to 36, and disabling Kotlin incremental compilation

## Validation
- ran `./.fvm/flutter_sdk/bin/flutter build ios --flavor prod -t lib/main_prod.dart --no-codesign`
- reran Android bundle build locally to verify the ABI conflict and SDK-level issues were resolved
