### PR TITLE
Fix FCM launch flow and tag content loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .buildlog/
 .history
 .svn/
+docs/
 
 # IntelliJ related
 *.iml

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/prod.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/prod.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug-prod"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -43,6 +44,7 @@
       buildConfiguration = "Debug-prod"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import UserNotifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
@@ -7,6 +8,16 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // 讓 firebase_messaging 能透過 FlutterAppDelegate 的 plugin 轉發機制
+    // 收到 UNUserNotificationCenter 的 callback（前景顯示、點擊通知等）。
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self
+    }
+
+    // 主動向 APNs 註冊，避免在某些情況下（特別是 iOS Simulator）APNs token
+    // 取得延遲，導致 FCM 的 getInitialMessage / token 流程卡住。
+    application.registerForRemoteNotifications()
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 

--- a/lib/controller/initial_app_controller.dart
+++ b/lib/controller/initial_app_controller.dart
@@ -32,6 +32,7 @@ class InitialAppController extends GetxController {
     isLoading.value = true;
     error.value = null;
     isConfigReady.value = false;
+    print('[initial-app-controller] loadConfig started');
 
     try {
       final FirebaseRemoteConfig remoteConfig = FirebaseRemoteConfig.instance;
@@ -49,6 +50,7 @@ class InitialAppController extends GetxController {
       });
 
       await remoteConfig.fetchAndActivate();
+      print('[initial-app-controller] Remote config fetched and activated');
 
       minAppVersion.value = remoteConfig.getString('min_version_number');
       final bool useTemporaryK6Routes =
@@ -62,18 +64,25 @@ class InitialAppController extends GetxController {
       );
 
       ArticlesApiProvider.instance.initGraphQLLink();
+      print('[initial-app-controller] GraphQL link initialized');
       _refreshElectionDataProvider();
+      print('[initial-app-controller] Election data provider refreshed');
       await configRepos.loadTheConfig();
+      print('[initial-app-controller] App config loaded');
       await MobileAds.instance.initialize();
+      print('[initial-app-controller] Mobile Ads initialized');
 
       final PackageInfo packageInfo = await PackageInfo.fromPlatform();
       appVersion.value =
           'v${packageInfo.version}(${packageInfo.buildNumber})';
       isConfigReady.value = true;
+      print('[initial-app-controller] Config ready flag set to true');
     } catch (e) {
+      print('[initial-app-controller] loadConfig failed: $e');
       error.value = UnknownException(e.toString());
     } finally {
       isLoading.value = false;
+      print('[initial-app-controller] loadConfig finished');
     }
   }
 

--- a/lib/controller/show_playlist_controller.dart
+++ b/lib/controller/show_playlist_controller.dart
@@ -29,6 +29,8 @@ class ShowPlaylistController extends GetxController {
   }
 
   Future<void> fetchInitial() async {
+    // ===== 選單排查 log =====
+    print('[選單排查] Controller.fetchInitial 開始 playlistId="$playlistId"');
     isLoading.value = true;
     error.value = null;
 
@@ -38,8 +40,12 @@ class ShowPlaylistController extends GetxController {
         maxResults: maxResults,
       );
       youtubePlaylistItemList.assignAll(items);
+      print('[選單排查] Controller.fetchInitial 成功 '
+          'playlistId="$playlistId" items=${items.length}');
     } catch (e) {
       error.value = determineException(e);
+      print('[選單排查] Controller.fetchInitial 失敗 '
+          'playlistId="$playlistId" error=$e');
     } finally {
       isLoading.value = false;
     }

--- a/lib/controller/tag_controller.dart
+++ b/lib/controller/tag_controller.dart
@@ -20,13 +20,22 @@ class TagController extends GetxController {
   final Rxn<MNewException> error = Rxn<MNewException>();
   final RxInt allStoryCount = 0.obs;
 
+  static const int _pageSize = 10;
+
+  // 內部 posts 與外部 externals 各自的分頁游標 / 是否已載完。
+  // 兩個來源是獨立集合，必須各自記錄進度。
+  int _postsSkip = 0;
+  int _externalsSkip = 0;
+  bool _postsExhausted = false;
+  bool _externalsExhausted = false;
+
   bool get isInitState =>
       !isLoading.value &&
       !isLoadingMore.value &&
       error.value == null &&
       tagStoryList.isEmpty;
 
-  bool get isAllLoaded => tagStoryList.length >= allStoryCount.value;
+  bool get isAllLoaded => _postsExhausted && _externalsExhausted;
 
   @override
   void onInit() {
@@ -37,11 +46,27 @@ class TagController extends GetxController {
   Future<void> fetchStoryListByTagSlug() async {
     isLoading.value = true;
     error.value = null;
+    _postsSkip = 0;
+    _externalsSkip = 0;
+    _postsExhausted = false;
+    _externalsExhausted = false;
 
     try {
-      final stories = await tagStoryListRepos.fetchStoryListByTagSlug(tagSlug);
-      tagStoryList.assignAll(stories);
-      allStoryCount.value = tagStoryListRepos.allStoryCount;
+      final result = await tagStoryListRepos.fetchStoryListByTagSlug(
+        tagSlug,
+        first: _pageSize,
+        withCount: true,
+      );
+
+      _postsSkip = result.posts.length;
+      _externalsSkip = result.externals.length;
+      _postsExhausted = result.posts.length < _pageSize;
+      _externalsExhausted = result.externals.length < _pageSize;
+      allStoryCount.value = result.postsCount + result.externalsCount;
+
+      tagStoryList.assignAll(
+        _mergeSorted([...result.posts, ...result.externals]),
+      );
     } catch (e) {
       error.value = determineException(e);
     } finally {
@@ -55,15 +80,35 @@ class TagController extends GetxController {
     isLoadingMore.value = true;
 
     try {
-      final stories = await tagStoryListRepos.fetchStoryListByTagSlug(
+      final bool needPosts = !_postsExhausted;
+      final bool needExternals = !_externalsExhausted;
+
+      final result = await tagStoryListRepos.fetchStoryListByTagSlug(
         tagSlug,
-        skip: tagStoryList.length,
+        postsSkip: _postsSkip,
+        externalsSkip: _externalsSkip,
+        first: _pageSize,
         withCount: false,
+        fetchPosts: needPosts,
+        fetchExternals: needExternals,
       );
 
-      final existingIds = tagStoryList.map((item) => item.id).toSet();
-      final newStories = stories.where((item) => !existingIds.contains(item.id));
-      tagStoryList.addAll(newStories);
+      if (needPosts) {
+        _postsSkip += result.posts.length;
+        if (result.posts.length < _pageSize) _postsExhausted = true;
+      }
+      if (needExternals) {
+        _externalsSkip += result.externals.length;
+        if (result.externals.length < _pageSize) _externalsExhausted = true;
+      }
+
+      tagStoryList.assignAll(
+        _mergeSorted([
+          ...tagStoryList,
+          ...result.posts,
+          ...result.externals,
+        ]),
+      );
     } catch (e) {
       final snackBar = SnackBar(
         content: const Text('加載失敗'),
@@ -76,5 +121,26 @@ class TagController extends GetxController {
     } finally {
       isLoadingMore.value = false;
     }
+  }
+
+  /// 以 slug/id 去重，再依發佈時間（新 → 舊）排序。
+  /// 每次載入後都重排整份清單，確保 posts 與 externals 交錯後順序正確。
+  List<StoryListItem> _mergeSorted(List<StoryListItem> items) {
+    final seen = <String>{};
+    final result = <StoryListItem>[];
+    for (final item in items) {
+      final key = item.slug ?? item.id ?? item.url ?? '';
+      if (key.isEmpty || seen.add(key)) {
+        result.add(item);
+      }
+    }
+    result.sort((a, b) => _publishedAt(b).compareTo(_publishedAt(a)));
+    return result;
+  }
+
+  DateTime _publishedAt(StoryListItem item) {
+    final raw = item.publishTime ?? item.updatedAt;
+    return DateTime.tryParse(raw ?? '') ??
+        DateTime.fromMillisecondsSinceEpoch(0);
   }
 }

--- a/lib/helpers/firebaseMessagingHelper.dart
+++ b/lib/helpers/firebaseMessagingHelper.dart
@@ -1,63 +1,115 @@
+import 'dart:async';
+
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:tv/pages/story_page.dart';
 
-Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  // If you're going to use other Firebase services in the background, such as Firestore,
-  // make sure you call `initializeApp` before using other Firebase services.
-  print('Handling a background message ${message.messageId}');
+/// Background message handler.
+///
+/// 必須是 top-level 或 static function，並標記 `@pragma('vm:entry-point')`
+/// 以避免在 release / AOT build 下被 tree-shake 掉，造成背景推播完全收不到。
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  // 若日後需要在背景使用其他 Firebase 服務，記得先呼叫 Firebase.initializeApp()
+  debugPrint('[fcm-bg] Handling a background message ${message.messageId}');
 }
 
 class FirebaseMessagingHelper {
-  FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
-
   FirebaseMessagingHelper();
 
-  configFirebaseMessaging() async {
-    NotificationSettings settings = await _firebaseMessaging.requestPermission(
-      alert: true,
-      announcement: false,
-      badge: true,
-      carPlay: false,
-      criticalAlert: false,
-      provisional: false,
-      sound: true,
-    );
+  final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
 
-    print('User granted permission: ${settings.authorizationStatus}');
+  /// 暫存 cold-start 時收到的 initialMessage 對應的 story slug。
+  ///
+  /// `configFirebaseMessaging()` 是非阻塞、在首頁顯示前不一定完成的流程；
+  /// 即使取得到 `initialMessage`，當下 GetMaterialApp 的 navigator 也未必就緒，
+  /// 直接 `Get.to(...)` 會 silent fail。因此把要導頁的 slug 暫存起來，
+  /// 等 HomePage 掛載時再透過 [consumePendingStorySlug] 取出。
+  static String? _pendingStorySlug;
 
-    FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+  /// 取出並清空暫存的 deep link slug。連續呼叫只會成功一次。
+  static String? consumePendingStorySlug() {
+    final slug = _pendingStorySlug;
+    _pendingStorySlug = null;
+    return slug;
+  }
 
-    RemoteMessage? initialMessage =
-        await _firebaseMessaging.getInitialMessage();
-    if (initialMessage != null &&
-        initialMessage.data.containsKey('news_story_slug')) {
-      Get.to(() => StoryPage(
-            slug: initialMessage.data['news_story_slug'],
-          ));
+  Future<void> configFirebaseMessaging() async {
+    debugPrint('[fcm] Requesting notification permission');
+    try {
+      final NotificationSettings settings = await _firebaseMessaging
+          .requestPermission(
+            alert: true,
+            announcement: false,
+            badge: true,
+            carPlay: false,
+            criticalAlert: false,
+            provisional: false,
+            sound: true,
+          )
+          .timeout(const Duration(seconds: 5));
+      debugPrint(
+          '[fcm] User granted permission: ${settings.authorizationStatus}');
+    } on TimeoutException {
+      debugPrint('[fcm] requestPermission timed out, continuing app launch');
+    } catch (e) {
+      debugPrint('[fcm] requestPermission failed: $e');
     }
 
-    // Also handle any interaction when the app is in the background via a
-    // Stream listener
+    // initial message: 由 cold-start 通知點擊觸發
+    RemoteMessage? initialMessage;
+    try {
+      debugPrint('[fcm] Waiting for initial message');
+      initialMessage = await _firebaseMessaging
+          .getInitialMessage()
+          .timeout(const Duration(seconds: 3), onTimeout: () {
+        debugPrint('[fcm] getInitialMessage timed out, continuing app launch');
+        return null;
+      });
+      debugPrint('[fcm] Initial message resolved: ${initialMessage?.messageId}');
+    } catch (e) {
+      debugPrint('[fcm] getInitialMessage failed: $e');
+    }
+
+    final initialMessageData = initialMessage?.data;
+    if (initialMessageData != null &&
+        initialMessageData.containsKey('news_story_slug')) {
+      // 不直接 Get.to：此時可能還在 ConfigPage，Navigator 還沒就緒。
+      // 暫存 slug，由 HomePage 掛載後 (consumePendingStorySlug) 觸發導頁。
+      _pendingStorySlug = initialMessageData['news_story_slug']?.toString();
+      debugPrint('[fcm] Cached pending story slug: $_pendingStorySlug');
+    }
+
+    // 前景訊息（App 開著時收到）
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+      debugPrint('[fcm] onMessage received: ${message.messageId}, '
+          'data=${message.data}, notification=${message.notification?.title}');
+      // 預設 iOS 前景不會自動顯示 banner；若日後要做 in-app 提示，可在此擴充。
+    });
+    debugPrint('[fcm] Registered onMessage listener');
+
+    // 點擊背景通知（App 在背景被通知喚醒並開啟）
     FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
-      if (message.data.containsKey('news_story_slug')) {
+      debugPrint('[fcm] onMessageOpenedApp: ${message.messageId}');
+      final slug = message.data['news_story_slug']?.toString();
+      if (slug != null && slug.isNotEmpty) {
         Get.to(
-          () => StoryPage(
-            slug: message.data['news_story_slug'],
-          ),
+          () => StoryPage(slug: slug),
           preventDuplicates: false,
         );
       }
     });
+    debugPrint('[fcm] Registered onMessageOpenedApp listener');
   }
 
-  subscribeToTopic(String topic) {
+  void subscribeToTopic(String topic) {
     _firebaseMessaging.subscribeToTopic(topic);
   }
 
-  unsubscribeFromTopic(String topic) {
+  void unsubscribeFromTopic(String topic) {
     _firebaseMessaging.unsubscribeFromTopic(topic);
   }
 
-  dispose() {}
+  void dispose() {}
 }

--- a/lib/initialApp.dart
+++ b/lib/initialApp.dart
@@ -3,8 +3,10 @@ import 'package:get/get.dart';
 import 'package:tv/bindings/initial_app_binding.dart';
 import 'package:tv/controller/initial_app_controller.dart';
 import 'package:tv/helpers/dataConstants.dart';
+import 'package:tv/helpers/firebaseMessagingHelper.dart';
 import 'package:tv/pages/config_page.dart';
 import 'package:tv/pages/home_page.dart';
+import 'package:tv/pages/story_page.dart';
 import 'package:upgrader/upgrader.dart';
 import 'helpers/updateMessages.dart';
 
@@ -17,6 +19,7 @@ class InitialApp extends StatefulWidget {
 
 class _InitialAppState extends State<InitialApp> {
   late final InitialAppController controller;
+  bool _deepLinkHandled = false;
 
   @override
   void initState() {
@@ -25,16 +28,35 @@ class _InitialAppState extends State<InitialApp> {
     controller = Get.find<InitialAppController>();
   }
 
+  /// 在 HomePage 掛載後執行：消化 cold-start 通知帶過來的 deep link slug。
+  /// 只會成功一次：[FirebaseMessagingHelper.consumePendingStorySlug] 取出後即清空，
+  /// 同時 `_deepLinkHandled` 保證 Obx rebuild 也不會重複 push。
+  void _handlePendingDeepLink() {
+    if (_deepLinkHandled) return;
+    _deepLinkHandled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final slug = FirebaseMessagingHelper.consumePendingStorySlug();
+      if (slug != null && slug.isNotEmpty) {
+        debugPrint('[initial-app] Navigating to pending story: $slug');
+        Get.to(() => StoryPage(slug: slug));
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Obx(() {
       final error = controller.error.value;
       if (error != null) {
-        print('ConfigError: ${error.message}');
+        debugPrint('[initial-app] Showing error state: ${error.message}');
         return _errorMessage();
       }
 
       if (controller.isConfigReady.value) {
+        debugPrint(
+          '[initial-app] Config ready, showing HomePage with min version ${controller.minAppVersion.value}',
+        );
+        _handlePendingDeepLink();
         return UpgradeAlert(
           upgrader: Upgrader(
             minAppVersion: controller.minAppVersion.value,
@@ -46,6 +68,7 @@ class _InitialAppState extends State<InitialApp> {
         );
       }
 
+      debugPrint('[initial-app] Config not ready yet, showing ConfigPage');
       return ConfigPage();
     });
   }

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -2,10 +2,12 @@ import 'dart:io';
 
 import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:tv/helpers/environment.dart';
+import 'package:tv/helpers/firebaseMessagingHelper.dart';
 import 'package:tv/mNewsApp.dart';
 import 'package:tv/services/comscoreService.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
@@ -26,6 +28,9 @@ void main() async {
   // 初始化第三方 SDK
   MobileAds.instance.initialize();
   await Firebase.initializeApp();
+
+  // 背景訊息 handler 必須在 runApp 之前、Firebase init 之後盡早註冊。
+  FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
 
   FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
   // 初始化 Comscore (dev = 測試環境)

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -3,39 +3,57 @@ import 'dart:io';
 import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:tv/helpers/environment.dart';
+import 'package:tv/helpers/firebaseMessagingHelper.dart';
 import 'package:tv/mNewsApp.dart';
 import 'package:tv/services/comscoreService.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  debugPrint('[prod-init] WidgetsFlutterBinding initialized');
 
   // 初始化環境
   Environment().initConfig(BuildFlavor.production);
+  debugPrint('[prod-init] Environment configured');
 
   // iOS 要求追蹤權限
   if (Platform.isIOS) {
+    debugPrint('[prod-init] Requesting ATT permission');
     await Future.delayed(const Duration(milliseconds: 1000));
     await AppTrackingTransparency.requestTrackingAuthorization();
+    debugPrint('[prod-init] ATT permission request finished');
   }
 
   // 初始化第三方 SDK
+  debugPrint('[prod-init] Initializing Mobile Ads');
   MobileAds.instance.initialize();
+  debugPrint('[prod-init] Initializing Firebase');
   await Firebase.initializeApp();
+  debugPrint('[prod-init] Firebase initialized');
+  // 背景訊息 handler 必須在 runApp 之前、Firebase init 之後盡早註冊。
+  FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+  debugPrint('[prod-init] FCM background handler registered');
   FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+  debugPrint('[prod-init] Crashlytics handler registered');
 
   // 初始化 Comscore (prod = 正式環境)
+  debugPrint('[prod-init] Initializing Comscore');
   await ComscoreService.init(isProd: true);
+  debugPrint('[prod-init] Comscore initialized');
 
   // 鎖定螢幕方向
+  debugPrint('[prod-init] Setting preferred orientations');
   await SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,
   ]);
+  debugPrint('[prod-init] Preferred orientations set');
 
   // 啟動 App
+  debugPrint('[prod-init] Running app');
   runApp(MNewsApp());
 }

--- a/lib/models/storyListItem.dart
+++ b/lib/models/storyListItem.dart
@@ -215,6 +215,7 @@ class StoryListItem {
       isSales: false,
       categoryList: allPostsCategory,
       displayCategory: displayCategory,
+      publishTime: json['publishTime']?.toString(),
     );
   }
 

--- a/lib/models/youtubePlaylistInfo.dart
+++ b/lib/models/youtubePlaylistInfo.dart
@@ -7,20 +7,79 @@ class YoutubePlaylistInfo {
     required this.youtubePlayListId,
   });
 
+  /// 解析 CMS 後台 show 的 playList01 / playList02 欄位。
+  ///
+  /// 後台格式為「<playlist 連結>：<選單名稱>」,以「全形冒號」分隔。
+  /// 名稱可省略;若省略則使用 [defaultName]。
   static YoutubePlaylistInfo? parseByShow(String? json, String defaultName) {
     if (json == null) {
       return null;
     }
 
-    List<String> info = json.split('：');
-    String name = info.length < 2 ? defaultName : info[1];
-    String youtubePlayListId = '';
-    if (info[0] != '') {
-      youtubePlayListId = info[0].split('playlist?list=')[1];
+    final String raw = json.trim();
+    if (raw.isEmpty) {
+      return null;
     }
+
+    // 以全形冒號分隔「連結」與「名稱」。
+    final List<String> info = raw.split('：');
+    final String urlPart = info[0].trim();
+    final String namePart = info.length < 2 ? '' : info[1].trim();
+    final String name = namePart.isEmpty ? defaultName : namePart;
+
+    final String youtubePlayListId = _extractPlaylistId(urlPart);
+
+    // ===== 選單排查 log(排查完可整段移除)=====
+    print('[選單排查] parseByShow raw="$json" '
+        '=> id="$youtubePlayListId" name="$name"');
+
     return YoutubePlaylistInfo(
       name: name,
       youtubePlayListId: youtubePlayListId,
     );
+  }
+
+  /// 從 CMS 字串中取出乾淨的 YouTube playlist id。
+  ///
+  /// 支援下列情況,避免後台填法稍有差異就抓到壞掉的 id:
+  ///   - https://www.youtube.com/playlist?list=PLxxxx
+  ///   - https://www.youtube.com/playlist?list=PLxxxx&si=xxxx (分享連結帶參數)
+  ///   - https://www.youtube.com/watch?v=xxx&list=PLxxxx
+  ///   - 直接填純 playlist id (PLxxxx / UUxxxx ...)
+  ///   - 前後夾帶空白 / 換行
+  static String _extractPlaylistId(String input) {
+    final String value = input.trim();
+    if (value.isEmpty) {
+      return '';
+    }
+
+    String? candidate;
+
+    // 1. 優先用標準 URL 解析,直接讀 list 參數(會自動忽略 &si= 等其他參數)。
+    final Uri? uri = Uri.tryParse(value);
+    final String? listParam = uri?.queryParameters['list'];
+    if (listParam != null && listParam.trim().isNotEmpty) {
+      candidate = listParam.trim();
+    } else {
+      // 2. fallback:字串裡只要含 list= 就抓後面那段。
+      const String marker = 'list=';
+      final int markerIndex = value.indexOf(marker);
+      if (markerIndex >= 0) {
+        candidate = value.substring(markerIndex + marker.length);
+      } else if (!value.contains('/') && !value.contains(' ')) {
+        // 3. 沒有 URL 結構,當作後台直接填了純 id。
+        candidate = value;
+      }
+    }
+
+    if (candidate == null) {
+      return '';
+    }
+
+    // playlist id 僅由英數字、底線、連字號組成;
+    // 取開頭的合法片段,自動切掉 &si=、夾帶的名稱、空白、換行等雜訊。
+    final RegExpMatch? match =
+        RegExp(r'[A-Za-z0-9_-]+').firstMatch(candidate);
+    return match?.group(0) ?? '';
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -29,6 +29,7 @@ class _HomePageState extends State<HomePage> {
 
   @override
   void initState() {
+    debugPrint('[home-page] initState');
     _showGDPR();
     super.initState();
   }
@@ -36,8 +37,10 @@ class _HomePageState extends State<HomePage> {
   _showGDPR() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     bool? isFirstLaunch = prefs.getBool("isFirstLaunch");
+    debugPrint('[home-page] isFirstLaunch = $isFirstLaunch');
     if (isFirstLaunch == null || isFirstLaunch) {
       await Future.delayed(Duration(seconds: 1));
+      debugPrint('[home-page] Showing GDPR dialog');
       showDialog(
         context: context,
         barrierDismissible: false,
@@ -49,11 +52,15 @@ class _HomePageState extends State<HomePage> {
         },
       );
       await prefs.setBool("isFirstLaunch", false);
+      debugPrint('[home-page] GDPR first-launch flag saved');
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    debugPrint(
+      '[home-page] build with section ${appShellController.currentSection.value}',
+    );
     return Scaffold(
       key: _scaffoldkey,
       drawer: HomeDrawer(widget.appVersion),
@@ -92,6 +99,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   Widget _buildBody(MNewsSection sectionId) {
+    debugPrint('[home-page] building body for $sectionId');
     switch (sectionId) {
       case MNewsSection.news:
         return const NewsPage();

--- a/lib/pages/section/news/news_page.dart
+++ b/lib/pages/section/news/news_page.dart
@@ -17,6 +17,7 @@ class _NewsPageState extends State<NewsPage> {
   @override
   void initState() {
     super.initState();
+    debugPrint('[news-page] initState');
     NewsCategoryBinding().dependencies();
     NewsElectionBinding().dependencies();
   }
@@ -34,6 +35,7 @@ class _NewsPageState extends State<NewsPage> {
 
   @override
   Widget build(BuildContext context) {
+    debugPrint('[news-page] build');
     return const NewsCategoryTab();
   }
 }

--- a/lib/pages/section/show/show_playlist_tab_content.dart
+++ b/lib/pages/section/show/show_playlist_tab_content.dart
@@ -42,6 +42,9 @@ class _ShowPlaylistTabContentState extends State<ShowPlaylistTabContent> {
   @override
   void initState() {
     super.initState();
+    // ===== 選單排查 log =====
+    print('[選單排查] TabContent.initState tag=${widget.controllerTag} '
+        'playlistId="${widget.youtubePlaylistInfo.youtubePlayListId}"');
     ShowPlaylistBinding(
       controllerTag: widget.controllerTag,
       playlistId: widget.youtubePlaylistInfo.youtubePlayListId,
@@ -59,7 +62,21 @@ class _ShowPlaylistTabContentState extends State<ShowPlaylistTabContent> {
   }
 
   @override
+  void didUpdateWidget(covariant ShowPlaylistTabContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // ===== 選單排查 log =====
+    // 若切換選單時印出這行、且 old/new tag 不同,代表 State 被重用、
+    // initState 沒有重跑 —— 這就是選單 B 點了清單不更新的元兇。
+    final reused = oldWidget.controllerTag != widget.controllerTag;
+    print('[選單排查] TabContent.didUpdateWidget '
+        'old=${oldWidget.controllerTag} new=${widget.controllerTag}'
+        '${reused ? "  <-- State 被重用,initState 未重跑!" : ""}');
+  }
+
+  @override
   void dispose() {
+    // ===== 選單排查 log =====
+    print('[選單排查] TabContent.dispose tag=${widget.controllerTag}');
     if (Get.isRegistered<ShowPlaylistController>(tag: widget.controllerTag)) {
       Get.delete<ShowPlaylistController>(tag: widget.controllerTag);
     }
@@ -71,11 +88,17 @@ class _ShowPlaylistTabContentState extends State<ShowPlaylistTabContent> {
     return Obx(() {
       final error = controller.error.value;
       if (error != null) {
+        // ===== 選單排查 log =====
+        print('[選單排查] TabContent.build tag=${widget.controllerTag} '
+            '狀態=錯誤,顯示空白 Container | error=$error');
         return Container();
       }
 
       final youtubePlaylistItemList = controller.youtubePlaylistItemList.toList();
       if (youtubePlaylistItemList.isNotEmpty) {
+        // ===== 選單排查 log =====
+        print('[選單排查] TabContent.build tag=${widget.controllerTag} '
+            '狀態=有資料 count=${youtubePlaylistItemList.length}');
         return buildYoutubePlayListItemList(
           widget.youtubePlaylistInfo.youtubePlayListId,
           youtubePlaylistItemList,
@@ -83,6 +106,9 @@ class _ShowPlaylistTabContentState extends State<ShowPlaylistTabContent> {
         );
       }
 
+      // ===== 選單排查 log =====
+      print('[選單排查] TabContent.build tag=${widget.controllerTag} '
+          '狀態=空清單,顯示載入轉圈 | isLoading=${controller.isLoading.value}');
       return loadMoreWidget();
     });
   }

--- a/lib/pages/section/show/show_playlist_widget.dart
+++ b/lib/pages/section/show/show_playlist_widget.dart
@@ -27,6 +27,10 @@ class _ShowPlaylistWidgetState extends State<ShowPlaylistWidget> {
   @override
   void initState() {
     super.initState();
+    // ===== 選單排查 log =====
+    print('[選單排查] ShowPlaylistWidget.initState '
+        'A.id=${widget.showIntro.playList01?.youtubePlayListId} '
+        'B.id=${widget.showIntro.playList02?.youtubePlayListId}');
     if (widget.showIntro.playList01 != null &&
         widget.showIntro.playList02 != null) {
       initializeTabs(widget.showIntro);
@@ -34,6 +38,10 @@ class _ShowPlaylistWidgetState extends State<ShowPlaylistWidget> {
   }
 
   void initializeTabs(ShowIntro showIntro) {
+    // ===== 選單排查 log =====
+    print('[選單排查] initializeTabs '
+        'A(name=${showIntro.playList01!.name}, id=${showIntro.playList01!.youtubePlayListId}) | '
+        'B(name=${showIntro.playList02!.name}, id=${showIntro.playList02!.youtubePlayListId})');
     segmentedControlGroupValue = 0;
     tabs = <int, Widget>{
       0: Padding(
@@ -98,6 +106,9 @@ class _ShowPlaylistWidgetState extends State<ShowPlaylistWidget> {
             groupValue: segmentedControlGroupValue,
             children: tabs,
             onValueChanged: (int i) {
+              // ===== 選單排查 log:這就是「點擊選單」事件 =====
+              print('[選單排查] 點擊 segmented tab -> index=$i '
+                  '(0=選單A / 1=選單B)');
               setState(() {
                 segmentedControlGroupValue = i;
               });
@@ -115,7 +126,13 @@ class _ShowPlaylistWidgetState extends State<ShowPlaylistWidget> {
     String suffix,
   ) {
     final controllerTag = '${youtubePlaylistInfo.youtubePlayListId}_$suffix';
+    // ===== 選單排查 log =====
+    print('[選單排查] buildTabWidget 建立 tab widget tag=$controllerTag');
     return ShowPlaylistTabContent(
+      // key 讓 Flutter 切換選單時把舊分頁的 State dispose、建立新的 State;
+      // 少了 key,兩個分頁同為 ShowPlaylistTabContent 會共用同一個 State,
+      // initState 不會重跑 -> 點選單 B 時 binding/controller 不會重建,清單不更新。
+      key: ValueKey(controllerTag),
       controllerTag: controllerTag,
       youtubePlaylistInfo: youtubePlaylistInfo,
       listviewController: widget.listviewController,

--- a/lib/pages/tag/tag_widget.dart
+++ b/lib/pages/tag/tag_widget.dart
@@ -60,7 +60,11 @@ class _TagWidgetState extends State<TagWidget> {
             );
           }
           if (!controller.isLoadingMore.value) {
-            controller.fetchNextPageByTagSlug();
+            // 延後到本幀 build 結束後再觸發，避免在 build 期間改動 Rx
+            // 狀態（isLoadingMore）造成 setState() during build 例外
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              controller.fetchNextPageByTagSlug();
+            });
           }
           return const Center(child: CircularProgressIndicator.adaptive());
         }

--- a/lib/services/configService.dart
+++ b/lib/services/configService.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:tv/helpers/firebaseMessagingHelper.dart';
 
 abstract class ConfigRepos {
@@ -7,8 +10,16 @@ abstract class ConfigRepos {
 class ConfigServices implements ConfigRepos {
   @override
   Future<bool> loadTheConfig() async {
-    FirebaseMessagingHelper firebaseMessagingHelper = FirebaseMessagingHelper();
-    await firebaseMessagingHelper.configFirebaseMessaging();
+    // FCM 初始化（權限請求 / getInitialMessage / 註冊各種 listener）
+    // 在 iOS Simulator 上偶爾會卡住，且本質上不該阻塞首頁顯示。
+    // 改成 fire-and-forget：失敗也只記 log，不影響 App 啟動。
+    final FirebaseMessagingHelper firebaseMessagingHelper =
+        FirebaseMessagingHelper();
+    unawaited(
+      firebaseMessagingHelper.configFirebaseMessaging().catchError((Object e) {
+        debugPrint('[fcm] configFirebaseMessaging failed (non-fatal): $e');
+      }),
+    );
     return true;
   }
 }

--- a/lib/services/tabStoryListService.dart
+++ b/lib/services/tabStoryListService.dart
@@ -333,7 +333,7 @@ query {
         }
         skip: \$skip
         take: \$take
-        orderBy: [{ updatedAt: desc }]
+        orderBy: [{ publishTime: desc }]
       ) {
         id
         slug

--- a/lib/services/tagStoryListService.dart
+++ b/lib/services/tagStoryListService.dart
@@ -6,172 +6,234 @@ import 'package:tv/helpers/environment.dart';
 import 'package:tv/models/graphqlBody.dart';
 import 'package:tv/models/storyListItem.dart';
 
-abstract class TagStoryListRepos {
-  Future<List<StoryListItem>> fetchStoryListByTagSlug(
-      String slug, {
-        int skip = 0,
-        int first = 10,
-        bool withCount = true,
-      });
+/// tag 頁一次抓取的結果。
+///
+/// 內部文章（posts）與外部夥伴文章（externals，例如鏡報 / Mirror Daily）是
+/// CMS 內兩個各自獨立的集合，這裡分開回傳，由 controller 各自維護分頁游標、
+/// 再依發佈時間合併排序。
+class TagStoryListResult {
+  final List<StoryListItem> posts;
+  final List<StoryListItem> externals;
+  final int postsCount;
+  final int externalsCount;
 
-  int allStoryCount = 0;
+  const TagStoryListResult({
+    this.posts = const [],
+    this.externals = const [],
+    this.postsCount = 0,
+    this.externalsCount = 0,
+  });
+}
+
+abstract class TagStoryListRepos {
+  Future<TagStoryListResult> fetchStoryListByTagSlug(
+    String slug, {
+    int postsSkip = 0,
+    int externalsSkip = 0,
+    int first = 10,
+    bool withCount = true,
+    bool fetchPosts = true,
+    bool fetchExternals = true,
+  });
 }
 
 class TagStoryListServices implements TagStoryListRepos {
   final ApiBaseHelper _helper = ApiBaseHelper();
 
-  @override
-  int allStoryCount = 0;
-
-  final String query = """
-  query (
-    \$where: PostWhereInput,
-    \$skip: Int,
-    \$take: Int,
-    \$withCount: Boolean!
-  ) {
+  // 內部文章
+  final String _postsQuery = """
+  query (\$slug: String, \$skip: Int, \$take: Int, \$withCount: Boolean!) {
     posts(
-      where: \$where,
-      skip: \$skip,
-      take: \$take,
+      where: {
+        state: { equals: "published" }
+        tags: { some: { slug: { equals: \$slug } } }
+      }
+      skip: \$skip
+      take: \$take
       orderBy: [{ publishTime: desc }]
     ) {
       id
       slug
       name
       style
-
-      heroImage {
-        imageApiData
-      }
-
-      heroVideo {
-        coverPhoto {
-          imageApiData
-        }
-      }
-
-      categories {
-        id
-        slug
-        name
-      }
+      publishTime
+      heroImage { imageApiData }
+      heroVideo { coverPhoto { imageApiData } }
+      categories { id slug name }
     }
-
     postsCount(
-      where: \$where
+      where: {
+        state: { equals: "published" }
+        tags: { some: { slug: { equals: \$slug } } }
+      }
+    ) @include(if: \$withCount)
+  }
+  """;
+
+  // 外部夥伴文章（鏡報 / Mirror Daily 等，存在獨立的 externals 集合）
+  final String _externalsQuery = """
+  query (\$slug: String, \$skip: Int, \$take: Int, \$withCount: Boolean!) {
+    externals(
+      where: {
+        state: { equals: "published" }
+        tags: { some: { slug: { equals: \$slug } } }
+      }
+      skip: \$skip
+      take: \$take
+      orderBy: [{ publishTime: desc }]
+    ) {
+      id
+      slug
+      name
+      subtitle
+      publishTime
+      updatedAt
+      thumbnail
+      partner { id name slug }
+      categories { id slug name }
+    }
+    externalsCount(
+      where: {
+        state: { equals: "published" }
+        tags: { some: { slug: { equals: \$slug } } }
+      }
     ) @include(if: \$withCount)
   }
   """;
 
   @override
-  Future<List<StoryListItem>> fetchStoryListByTagSlug(
-      String slug, {
-        int skip = 0,
-        int first = 10,
-        bool withCount = true,
-      }) async {
+  Future<TagStoryListResult> fetchStoryListByTagSlug(
+    String slug, {
+    int postsSkip = 0,
+    int externalsSkip = 0,
+    int first = 10,
+    bool withCount = true,
+    bool fetchPosts = true,
+    bool fetchExternals = true,
+  }) async {
     print('===== fetchStoryListByTagSlug start =====');
-    print('incoming slug = $slug');
+    print('slug = $slug, postsSkip = $postsSkip (fetch=$fetchPosts), '
+        'externalsSkip = $externalsSkip (fetch=$fetchExternals)');
 
-    // ---------- 第一段：用 slug 查 ----------
-    List<StoryListItem> result = await _fetch(
-      slug,
-      isUseId: false,
-      skip: skip,
-      first: first,
-      withCount: withCount,
+    // 內外兩來源同時查，互不阻塞
+    final results = await Future.wait([
+      fetchPosts
+          ? _fetchPosts(slug, skip: postsSkip, first: first, withCount: withCount)
+          : Future<_Chunk>.value(const _Chunk.empty()),
+      fetchExternals
+          ? _fetchExternals(slug,
+              skip: externalsSkip, first: first, withCount: withCount)
+          : Future<_Chunk>.value(const _Chunk.empty()),
+    ]);
+
+    final _Chunk postsChunk = results[0];
+    final _Chunk externalsChunk = results[1];
+
+    print('posts = ${postsChunk.items.length} / count ${postsChunk.count}');
+    print('externals = ${externalsChunk.items.length} / count ${externalsChunk.count}');
+    print('===== fetchStoryListByTagSlug end =====');
+
+    return TagStoryListResult(
+      posts: postsChunk.items,
+      externals: externalsChunk.items,
+      postsCount: postsChunk.count,
+      externalsCount: externalsChunk.count,
     );
+  }
 
-    // ---------- fallback：如果查不到 → 改用 id ----------
-    if (result.isEmpty) {
-      print('⚠️ slug 查不到，改用 id 再查一次');
-
-      result = await _fetch(
-        slug,
-        isUseId: true,
+  /// 內部 posts：發生錯誤往外丟，讓 controller 顯示錯誤畫面（例如無網路）。
+  Future<_Chunk> _fetchPosts(
+    String slug, {
+    required int skip,
+    required int first,
+    required bool withCount,
+  }) async {
+    try {
+      final jsonResponse = await _post(
+        key: 'fetchTagPosts?slug=$slug&skip=$skip&first=$first',
+        query: _postsQuery,
+        slug: slug,
         skip: skip,
         first: first,
         withCount: withCount,
       );
-    }
-
-    print('===== fetchStoryListByTagSlug end =====');
-    return result;
-  }
-
-  Future<List<StoryListItem>> _fetch(
-      String value, {
-        required bool isUseId,
-        required int skip,
-        required int first,
-        required bool withCount,
-      }) async {
-    final key =
-        'fetchTag?value=$value&type=${isUseId ? "id" : "slug"}&skip=$skip&first=$first';
-
-    print('---- _fetch start ----');
-    print('use ${isUseId ? "id" : "slug"} = $value');
-
-    final Map<String, dynamic> variables = {
-      "where": {
-        "state": {"equals": "published"},
-        "tags": {
-          "some": isUseId
-              ? {
-            "id": {"equals": value}
-          }
-              : {
-            "slug": {"equals": value}
-          }
-        }
-      },
-      "skip": skip,
-      "take": first,
-      "withCount": withCount,
-    };
-
-    print('variables = ${jsonEncode(variables)}');
-
-    final GraphqlBody graphqlBody = GraphqlBody(
-      operationName: null,
-      query: query,
-      variables: variables,
-    );
-
-    print('request = ${jsonEncode(graphqlBody.toJson())}');
-
-    try {
-      final jsonResponse = await _helper.postByCacheAndAutoCache(
-        key,
-        Environment().config.graphqlApi,
-        jsonEncode(graphqlBody.toJson()),
-        maxAge: newsTabStoryList,
-        headers: {"Content-Type": "application/json"},
-      );
-
-      print('response = $jsonResponse');
-
-      final List<dynamic> posts =
+      final List<dynamic> raw =
           (jsonResponse['data']?['posts'] as List?) ?? [];
-
-      print('posts length = ${posts.length}');
-
-      final List<StoryListItem> list = List<StoryListItem>.from(
-        posts.map((post) => StoryListItem.fromJson(post)),
+      return _Chunk(
+        items: raw.map((post) => StoryListItem.fromJson(post)).toList(),
+        count: (jsonResponse['data']?['postsCount'] as num?)?.toInt() ?? 0,
       );
-
-      if (withCount) {
-        allStoryCount = jsonResponse['data']?['postsCount'] ?? 0;
-      }
-
-      print('postsCount = $allStoryCount');
-      print('---- _fetch end ----');
-
-      return list;
     } catch (e) {
-      print('❌ _fetch error = $e');
+      print('❌ _fetchPosts error = $e');
       rethrow;
     }
   }
+
+  /// 外部 externals：屬於附加內容，查詢失敗時不影響內部 posts，回傳空集合即可。
+  Future<_Chunk> _fetchExternals(
+    String slug, {
+    required int skip,
+    required int first,
+    required bool withCount,
+  }) async {
+    try {
+      final jsonResponse = await _post(
+        key: 'fetchTagExternals?slug=$slug&skip=$skip&first=$first',
+        query: _externalsQuery,
+        slug: slug,
+        skip: skip,
+        first: first,
+        withCount: withCount,
+      );
+      final List<dynamic> raw =
+          (jsonResponse['data']?['externals'] as List?) ?? [];
+      return _Chunk(
+        items: raw.map((post) => StoryListItem.fromJson(post)).toList(),
+        count: (jsonResponse['data']?['externalsCount'] as num?)?.toInt() ?? 0,
+      );
+    } catch (e) {
+      print('❌ _fetchExternals error = $e（tag 頁將只顯示內部文章）');
+      return const _Chunk.empty();
+    }
+  }
+
+  Future<dynamic> _post({
+    required String key,
+    required String query,
+    required String slug,
+    required int skip,
+    required int first,
+    required bool withCount,
+  }) async {
+    final GraphqlBody body = GraphqlBody(
+      operationName: null,
+      query: query,
+      variables: {
+        "slug": slug,
+        "skip": skip,
+        "take": first,
+        "withCount": withCount,
+      },
+    );
+
+    return _helper.postByCacheAndAutoCache(
+      key,
+      Environment().config.graphqlApi,
+      jsonEncode(body.toJson()),
+      maxAge: newsTabStoryList,
+      headers: {"Content-Type": "application/json"},
+    );
+  }
+}
+
+/// 單一來源（posts 或 externals）一次抓取的內容。
+class _Chunk {
+  final List<StoryListItem> items;
+  final int count;
+
+  const _Chunk({required this.items, required this.count});
+
+  const _Chunk.empty()
+      : items = const [],
+        count = 0;
 }

--- a/lib/services/youtubePlaylistService.dart
+++ b/lib/services/youtubePlaylistService.dart
@@ -18,10 +18,17 @@ class YoutubePlaylistServices implements YoutubePlaylistRepos {
   @override
   Future<List<YoutubePlaylistItem>> fetchSnippetByPlaylistId(String playlistId,
       {int maxResults = 5}) async {
-    final jsonResponse = await _helper.getByCacheAndAutoCache(
-        Environment().config.youtubeApi +
-            '/playlistItems?part=snippet&playlistId=$playlistId&maxResults=$maxResults',
+    final String requestUrl = Environment().config.youtubeApi +
+        '/playlistItems?part=snippet&playlistId=$playlistId&maxResults=$maxResults';
+    // ===== 選單排查 log =====
+    print('[選單排查] YoutubePlaylistService 請求 URL=$requestUrl');
+    final jsonResponse = await _helper.getByCacheAndAutoCache(requestUrl,
         maxAge: youtubePlayListCacheDuration);
+
+    // ===== 選單排查 log =====
+    print('[選單排查] YoutubePlaylistService 回應 '
+        'keys=${jsonResponse is Map ? jsonResponse.keys.toList() : jsonResponse.runtimeType} '
+        'itemsCount=${jsonResponse is Map && jsonResponse['items'] is List ? (jsonResponse['items'] as List).length : "N/A(可能是錯誤回應)"}');
 
     _nextPageToken = jsonResponse['nextPageToken'];
 


### PR DESCRIPTION
## Summary
- make FCM startup handling non-blocking and cache cold-start notification story slugs until navigation is ready
- register iOS notification callbacks/APNs earlier and document the iOS simulator `getInitialMessage()` hang investigation
- load tag pages from both posts and externals with separate pagination, merge sorting, and deduplication
- harden show playlist parsing against noisy YouTube playlist URLs

## Verification
- `git diff --cached --check` passed before commit
- `fvm flutter analyze` ran with Flutter 3.41.5 and reported existing analyzer warnings/infos (68 issues), including pre-existing deprecated API and null-aware warnings; no new compile error surfaced
