### PR TITLE
Fix FCM launch flow and article embeds

### DIFF
--- a/lib/pages/section/news/news_page_controller.dart
+++ b/lib/pages/section/news/news_page_controller.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:tv/controller/initial_app_controller.dart';
 import 'package:tv/core/enum/page_status.dart';
 import 'package:tv/models/storyListItem.dart';
 import 'package:tv/provider/articles_api_provider.dart';
@@ -25,7 +26,10 @@ class NewsPageController extends GetxController {
   @override
   void onInit() async {
     super.onInit();
-    await firebaseRemoteConfig.fetchAndActivate();
+    // InitialAppController 已負責 fetchAndActivate，這裡等它完成再讀值，
+    // 避免兩個並行 fetch 造成 firebase_remote_config "cancelled" 例外、
+    // 導致 onInit 中斷使 election/banner/liveUrl/editorChoice/文章清單都沒載到。
+    await _waitForRemoteConfigReady();
     rxIsElectionShow.value = firebaseRemoteConfig.getBool('isElectionShow');
     rxIsBannerShow.value = firebaseRemoteConfig.getBool('isBannerShow');
     String? bannerJsonString = firebaseRemoteConfig.getString('BannerURL');
@@ -50,6 +54,21 @@ class NewsPageController extends GetxController {
     if (scrollController.position.pixels ==
         scrollController.position.maxScrollExtent) {
       fetchMoreArticle();
+    }
+  }
+
+  /// 等 InitialAppController 把 remote config fetchAndActivate 完成。
+  /// 若 InitialAppController 載入失敗（error 已設），也讓流程繼續，
+  /// 後續的 getBool/getString 會落回 setDefaults 設定的預設值。
+  Future<void> _waitForRemoteConfigReady() async {
+    while (true) {
+      if (Get.isRegistered<InitialAppController>()) {
+        final InitialAppController controller =
+            Get.find<InitialAppController>();
+        if (controller.isConfigReady.value) return;
+        if (controller.error.value != null) return;
+      }
+      await Future.delayed(const Duration(milliseconds: 50));
     }
   }
 

--- a/lib/widgets/embedded_code/src/platform/ytEmbeddedCodeWidget.dart
+++ b/lib/widgets/embedded_code/src/platform/ytEmbeddedCodeWidget.dart
@@ -1,5 +1,10 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+
+const String _youtubeEmbedOrigin = 'https://www.mnews.tw';
+const String _youtubeEmbedBaseUrl = '$_youtubeEmbedOrigin/';
 
 class YtEmbeddedCodeWidget extends StatefulWidget {
   final String embeddedCode;
@@ -24,15 +29,21 @@ class _YtEmbeddedCodeWidgetState extends State<YtEmbeddedCodeWidget> {
   void initState() {
     super.initState();
 
-    _iframeSrc = _extractSrcFromIframe(widget.embeddedCode);
+    _iframeSrc = _normalizeYoutubeEmbedSrc(
+      _extractSrcFromIframe(widget.embeddedCode),
+    );
     _aspectRatio = widget.aspectRatio ?? _extractAspectRatio();
 
     if (_iframeSrc != null) {
+      final escapedIframeSrc = const HtmlEscape().convert(_iframeSrc!);
       final htmlContent = '''
         <!DOCTYPE html>
         <html>
           <head>
+            <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <meta name="referrer" content="strict-origin-when-cross-origin">
+            <base href="$_youtubeEmbedBaseUrl">
             <style>
               body, html {
                 margin: 0;
@@ -58,8 +69,9 @@ class _YtEmbeddedCodeWidgetState extends State<YtEmbeddedCodeWidget> {
           <body>
             <div class="video-container">
               <iframe
-                src="$_iframeSrc"
+                src="$escapedIframeSrc"
                 title="YouTube video player"
+                referrerpolicy="strict-origin-when-cross-origin"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                 allowfullscreen>
               </iframe>
@@ -68,20 +80,21 @@ class _YtEmbeddedCodeWidgetState extends State<YtEmbeddedCodeWidget> {
         </html>
       ''';
 
-      _controller = WebViewController()
-        ..setJavaScriptMode(JavaScriptMode.unrestricted)
-        ..loadHtmlString(htmlContent);
+      _controller =
+          WebViewController()
+            ..setJavaScriptMode(JavaScriptMode.unrestricted)
+            ..loadHtmlString(htmlContent, baseUrl: _youtubeEmbedBaseUrl);
     }
   }
 
   double _extractAspectRatio() {
     try {
-      final width = RegExp(r'width="(\d+)"')
-          .firstMatch(widget.embeddedCode)
-          ?.group(1);
-      final height = RegExp(r'height="(\d+)"')
-          .firstMatch(widget.embeddedCode)
-          ?.group(1);
+      final width = RegExp(
+        r'width="(\d+)"',
+      ).firstMatch(widget.embeddedCode)?.group(1);
+      final height = RegExp(
+        r'height="(\d+)"',
+      ).firstMatch(widget.embeddedCode)?.group(1);
       if (width != null && height != null) {
         return double.parse(width) / double.parse(height);
       }
@@ -90,8 +103,32 @@ class _YtEmbeddedCodeWidgetState extends State<YtEmbeddedCodeWidget> {
   }
 
   String? _extractSrcFromIframe(String code) {
-    final match = RegExp(r'src="([^"]+)"').firstMatch(code);
+    final match = RegExp(
+      r'''src\s*=\s*["']([^"']+)["']''',
+      caseSensitive: false,
+    ).firstMatch(code);
     return match?.group(1);
+  }
+
+  String? _normalizeYoutubeEmbedSrc(String? src) {
+    if (src == null || src.trim().isEmpty) return null;
+
+    final unescapedSrc = src
+        .trim()
+        .replaceAll('&amp;', '&')
+        .replaceAll('&#38;', '&');
+    final normalizedSrc =
+        unescapedSrc.startsWith('//') ? 'https:$unescapedSrc' : unescapedSrc;
+    final uri = Uri.tryParse(normalizedSrc);
+    if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+      return normalizedSrc;
+    }
+
+    final queryParameters = Map<String, String>.from(uri.queryParameters);
+    queryParameters.putIfAbsent('origin', () => _youtubeEmbedOrigin);
+    queryParameters.putIfAbsent('playsinline', () => '1');
+
+    return uri.replace(queryParameters: queryParameters).toString();
   }
 
   @override


### PR DESCRIPTION
## Summary
- Fix FCM launch routing/tag content loading flow.
- Wait for InitialAppController remote config readiness before NewsPage reads flags, avoiding concurrent fetchAndActivate cancellation.
- Fix article YouTube iframe embeds by providing mnews origin/baseUrl, referrer policy, origin query param, and inline playback params to avoid YouTube error 153.

## Verification
- .fvm/flutter_sdk/bin/flutter analyze lib/pages/section/news/news_page_controller.dart lib/widgets/embedded_code/src/platform/ytEmbeddedCodeWidget.dart
- git diff --check