### PR TITLE
Stabilize category tabs with external articles

### DIFF
--- a/lib/models/storyListItem.dart
+++ b/lib/models/storyListItem.dart
@@ -85,7 +85,8 @@ class StoryListItem {
     if (json['adPost'] is Map<String, dynamic>) {
       final adPost = json['adPost'] as Map<String, dynamic>;
 
-      photoUrl = _extractImageUrlFromNode(adPost['heroImage']) ??
+      photoUrl =
+          _extractImageUrlFromNode(adPost['heroImage']) ??
           Environment().config.mirrorNewsDefaultImageUrl;
     }
 
@@ -93,7 +94,9 @@ class StoryListItem {
     List<Category>? allPostsCategory;
     if (json['adPost']?['categories'] != null) {
       allPostsCategory = List<Category>.from(
-        json['adPost']['categories'].map((category) => Category.fromJson(category)),
+        json['adPost']['categories'].map(
+          (category) => Category.fromJson(category),
+        ),
       );
       if (allPostsCategory.isNotEmpty) {
         displayCategory = allPostsCategory.first.name;
@@ -129,12 +132,15 @@ class StoryListItem {
         url: url,
         slug: parsed?.slug,
         linkType: parsed?.type,
-        photoUrl: (cover != null && cover.isNotEmpty)
-            ? cover
-            : Environment().config.mirrorNewsDefaultImageUrl,
-        displayCategory: json['custom_attributes'] is Map
-            ? (json['custom_attributes']['article:section']?.toString() ?? '')
-            : '',
+        photoUrl:
+            (cover != null && cover.isNotEmpty)
+                ? cover
+                : Environment().config.mirrorNewsDefaultImageUrl,
+        displayCategory:
+            json['custom_attributes'] is Map
+                ? (json['custom_attributes']['article:section']?.toString() ??
+                    '')
+                : '',
       );
     }
 
@@ -148,11 +154,13 @@ class StoryListItem {
         id: json[BaseModel.idKey]?.toString(),
         name: json[BaseModel.nameKey],
         slug: json[BaseModel.slugKey],
+        linkType: StoryLinkType.external,
         subtitle: json['subtitle'],
         url: json['url']?.toString(),
-        photoUrl: (json['thumbnail']?.toString().isNotEmpty ?? false)
-            ? json['thumbnail'].toString()
-            : Environment().config.mirrorNewsDefaultImageUrl,
+        photoUrl:
+            (json['thumbnail']?.toString().isNotEmpty ?? false)
+                ? json['thumbnail'].toString()
+                : Environment().config.mirrorNewsDefaultImageUrl,
         heroCaption: json['heroCaption'],
         brief: json['brief'],
         content: json['content'],
@@ -162,19 +170,25 @@ class StoryListItem {
         updatedAt: json['updatedAt'],
         source: json['source'],
         partnerName: json['partner']?['name'],
-        categoryList: json['categories'] != null
-            ? List<Category>.from(json['categories'].map((c) => Category.fromJson(c)))
-            : [],
-        displayCategory: (json['categories'] != null && (json['categories'] as List).isNotEmpty)
-            ? json['categories'][0]['name']
-            : "鏡報",
+        categoryList:
+            json['categories'] != null
+                ? List<Category>.from(
+                  json['categories'].map((c) => Category.fromJson(c)),
+                )
+                : [],
+        displayCategory:
+            (json['categories'] != null &&
+                    (json['categories'] as List).isNotEmpty)
+                ? json['categories'][0]['name']
+                : "鏡報",
       );
     }
 
     String photoUrl = Environment().config.mirrorNewsDefaultImageUrl;
 
     // K6 優先：heroImage.imageApiData
-    photoUrl = _extractImageUrlFromNode(json['heroImage']) ??
+    photoUrl =
+        _extractImageUrlFromNode(json['heroImage']) ??
         _extractImageUrlFromNode(json['heroVideo']?['coverPhoto']) ??
         Environment().config.mirrorNewsDefaultImageUrl;
     if (photoUrl == Environment().config.mirrorNewsDefaultImageUrl) {
@@ -223,9 +237,10 @@ class StoryListItem {
     if (imageNode == null) return null;
     if (imageNode is! Map) return null;
 
-    final map = imageNode is Map<String, dynamic>
-        ? imageNode
-        : Map<String, dynamic>.from(imageNode);
+    final map =
+        imageNode is Map<String, dynamic>
+            ? imageNode
+            : Map<String, dynamic>.from(imageNode);
 
     final imageApiData = map['imageApiData'];
     final k6Url = _extractUrlFromImageApiData(imageApiData);
@@ -250,9 +265,10 @@ class StoryListItem {
         return value;
       }
       if (value is Map) {
-        final nested = value is Map<String, dynamic>
-            ? value
-            : Map<String, dynamic>.from(value);
+        final nested =
+            value is Map<String, dynamic>
+                ? value
+                : Map<String, dynamic>.from(value);
 
         final nestedUrl = nested['url'];
         if (nestedUrl is String && nestedUrl.isNotEmpty) {

--- a/lib/pages/section/news/shared/news_story_first_item.dart
+++ b/lib/pages/section/news/shared/news_story_first_item.dart
@@ -22,55 +22,62 @@ class NewsStoryFirstItem extends StatelessWidget {
     final TextScaleFactorController textScaleFactorController = Get.find();
     double width = MediaQuery.of(context).size.width;
     return InkWell(
-        child: Column(
-          children: [
-            CachedNetworkImage(
-              height: width / 16 * 9,
-              width: width,
-              imageUrl: storyListItem.photoUrl,
-              placeholder: (context, url) => Container(
-                height: width / 16 * 9,
-                width: width,
-                color: Colors.grey,
-              ),
-              errorWidget: (context, url, error) => Container(
-                height: width / 16 * 9,
-                width: width,
-                color: Colors.grey,
-                child: Icon(Icons.error),
-              ),
-              fit: BoxFit.cover,
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 8.0),
-              child: Obx(
-                () => ExtendedText(
-                  storyListItem.name ?? StringDefault.nullString,
-                  joinZeroWidthSpace: true,
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 3,
-                  style: TextStyle(
-                    color: Colors.black,
-                    fontSize: 20.0,
-                    height: 1.5,
-                  ),
-                  textScaler: TextScaler.linear(
-                      textScaleFactorController.textScaleFactor.value),
+      child: Column(
+        children: [
+          CachedNetworkImage(
+            height: width / 16 * 9,
+            width: width,
+            imageUrl: storyListItem.photoUrl,
+            placeholder:
+                (context, url) => Container(
+                  height: width / 16 * 9,
+                  width: width,
+                  color: Colors.grey,
+                ),
+            errorWidget:
+                (context, url, error) => Container(
+                  height: width / 16 * 9,
+                  width: width,
+                  color: Colors.grey,
+                  child: Icon(Icons.error),
+                ),
+            fit: BoxFit.cover,
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 8.0),
+            child: Obx(
+              () => ExtendedText(
+                storyListItem.name ?? StringDefault.nullString,
+                joinZeroWidthSpace: true,
+                overflow: TextOverflow.ellipsis,
+                maxLines: 3,
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: 20.0,
+                  height: 1.5,
+                ),
+                textScaler: TextScaler.linear(
+                  textScaleFactorController.textScaleFactor.value,
                 ),
               ),
             ),
-          ],
-        ),
-        onTap: () {
-          AnalyticsHelper.logClick(
+          ),
+        ],
+      ),
+      onTap: () {
+        AnalyticsHelper.logClick(
+          slug: storyListItem.slug ?? StringDefault.nullString,
+          title: storyListItem.name ?? StringDefault.nullString,
+          location:
+              categorySlug == 'latest' ? 'HomePage_最新列表' : 'CategoryPage_列表',
+        );
+        Get.to(
+          () => StoryPage(
             slug: storyListItem.slug ?? StringDefault.nullString,
-            title: storyListItem.name ?? StringDefault.nullString,
-            location:
-                categorySlug == 'latest' ? 'HomePage_最新列表' : 'CategoryPage_列表',
-          );
-          Get.to(() => StoryPage(
-                slug: storyListItem.slug ?? StringDefault.nullString,
-              ));
-        });
+            linkType: storyListItem.linkType,
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/pages/section/news/shared/news_story_list_item.dart
+++ b/lib/pages/section/news/shared/news_story_list_item.dart
@@ -25,61 +25,66 @@ class NewsStoryListItem extends StatelessWidget {
     final TextScaleFactorController textScaleFactorController = Get.find();
 
     return InkWell(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 0.0),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              CachedNetworkImage(
-                height: imageSize,
-                width: imageSize,
-                imageUrl: storyListItem.photoUrl,
-                placeholder: (context, url) => Container(
-                  height: imageSize,
-                  width: imageSize,
-                  color: Colors.grey,
-                ),
-                errorWidget: (context, url, error) => Container(
-                  height: imageSize,
-                  width: imageSize,
-                  color: Colors.grey,
-                  child: Icon(Icons.error),
-                ),
-                fit: BoxFit.cover,
-              ),
-              SizedBox(
-                width: 16,
-              ),
-              Expanded(
-                child: Obx(
-                  () => ExtendedText(
-                    storyListItem.name ?? StringDefault.nullString,
-                    joinZeroWidthSpace: true,
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 3,
-                    style: TextStyle(
-                      color: Colors.black,
-                      fontSize: 20.0,
-                      height: 1.5,
-                    ),
-                    textScaler: TextScaler.linear(
-                        textScaleFactorController.textScaleFactor.value),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 0.0),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CachedNetworkImage(
+              height: imageSize,
+              width: imageSize,
+              imageUrl: storyListItem.photoUrl,
+              placeholder:
+                  (context, url) => Container(
+                    height: imageSize,
+                    width: imageSize,
+                    color: Colors.grey,
+                  ),
+              errorWidget:
+                  (context, url, error) => Container(
+                    height: imageSize,
+                    width: imageSize,
+                    color: Colors.grey,
+                    child: Icon(Icons.error),
+                  ),
+              fit: BoxFit.cover,
+            ),
+            SizedBox(width: 16),
+            Expanded(
+              child: Obx(
+                () => ExtendedText(
+                  storyListItem.name ?? StringDefault.nullString,
+                  joinZeroWidthSpace: true,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 3,
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontSize: 20.0,
+                    height: 1.5,
+                  ),
+                  textScaler: TextScaler.linear(
+                    textScaleFactorController.textScaleFactor.value,
                   ),
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
-        onTap: () {
-          AnalyticsHelper.logClick(
+      ),
+      onTap: () {
+        AnalyticsHelper.logClick(
+          slug: storyListItem.slug ?? StringDefault.nullString,
+          title: storyListItem.name ?? StringDefault.nullString,
+          location:
+              categorySlug == 'latest' ? 'HomePage_最新列表' : 'CategoryPage_列表',
+        );
+        Get.to(
+          () => StoryPage(
             slug: storyListItem.slug ?? StringDefault.nullString,
-            title: storyListItem.name ?? StringDefault.nullString,
-            location:
-                categorySlug == 'latest' ? 'HomePage_最新列表' : 'CategoryPage_列表',
-          );
-          Get.to(() => StoryPage(
-                slug: storyListItem.slug ?? StringDefault.nullString,
-              ));
-        });
+            linkType: storyListItem.linkType,
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/services/tabStoryListService.dart
+++ b/lib/services/tabStoryListService.dart
@@ -183,151 +183,25 @@ class TabStoryListServices implements TabStoryListRepos {
     int first = 20,
     bool withCount = true,
   }) async {
-    final int take = skip + first;
-    const String queryString = """
-query FetchCategoryStoryList(
-  \$slug: String!,
-  \$take: Int!,
-  \$withCount: Boolean!
-) {
-  posts(
-    where: {
-      state: { equals: "published" }
-      style: {
-        notIn: ["wide", "projects", "script", "campaign", "readr"]
-      }
-      categories: {
-        some: {
-          slug: { equals: \$slug }
-        }
-      }
-    }
-    take: \$take
-    orderBy: [{ publishTime: desc }]
-  ) {
-    id
-    slug
-    name
-    style
-    publishTime
-    heroImage {
-      imageApiData
-    }
-    heroVideo {
-      coverPhoto {
-        imageApiData
-      }
-    }
-    categories: categoriesInInputOrder {
-      id
-      slug
-      name
-    }
-  }
+    final int pageSize = first > skip ? first - skip : first;
+    final int take = skip + pageSize;
 
-  externals(
-    where: {
-      state: { equals: "published" }
-      categories: {
-        some: {
-          slug: { equals: \$slug }
-        }
-      }
-    }
-    take: \$take
-    orderBy: [{ publishTime: desc }]
-  ) {
-    id
-    slug
-    name
-    subtitle
-    state
-    partner {
-      id
-      name
-      slug
-    }
-    publishTime
-    byline
-    thumbnail
-    heroCaption
-    brief_original
-    content_original
-    brief
-    content
-    tags {
-      id
-      name
-      slug
-    }
-    categories: categoriesInInputOrder {
-      id
-      name
-      slug
-    }
-    source
-    updatedAt
-    createdAt
-  }
+    final results = await Future.wait([
+      _fetchCategoryPosts(slug, take: take, withCount: withCount),
+      _fetchCategoryExternals(slug, take: take, withCount: withCount),
+    ]);
 
-  postsCount(
-    where: {
-      state: { equals: "published" }
-      style: {
-        notIn: ["wide", "projects", "script", "campaign", "readr"]
-      }
-      categories: {
-        some: {
-          slug: { equals: \$slug }
-        }
-      }
-    }
-  ) @include(if: \$withCount)
-
-  externalsCount(
-    where: {
-      state: { equals: "published" }
-      categories: {
-        some: {
-          slug: { equals: \$slug }
-        }
-      }
-    }
-  ) @include(if: \$withCount)
-}
-""";
-
-    final GraphqlBody graphqlBody = GraphqlBody(
-      operationName: 'FetchCategoryStoryList',
-      query: queryString,
-      variables: {"slug": slug, "take": take, "withCount": withCount},
-    );
-
-    final jsonResponse = await _helper.postByUrl(
-      Environment().config.graphqlApi,
-      jsonEncode(graphqlBody.toJson()),
-      headers: {"Content-Type": "application/json"},
-    );
-
-    final List<dynamic> postJsonList =
-        (jsonResponse['data']?['posts'] as List?) ?? [];
-    final List<dynamic> externalJsonList =
-        (jsonResponse['data']?['externals'] as List?) ?? [];
+    final _CategoryChunk postsChunk = results[0];
+    final _CategoryChunk externalsChunk = results[1];
 
     final List<StoryListItem> newsList =
         _mergeSorted([
-          ...postJsonList.map((post) => StoryListItem.fromJson(post)),
-          ...externalJsonList.map(
-            (external) => StoryListItem.fromJson(external),
-          ),
-        ]).skip(skip).take(first).toList();
+          ...postsChunk.items,
+          ...externalsChunk.items,
+        ]).skip(skip).take(pageSize).toList();
 
     if (withCount) {
-      final int postsCount =
-          (jsonResponse['data']?['postsCount'] as num?)?.toInt() ?? 0;
-      final int externalsCount =
-          (jsonResponse['data']?['externalsCount'] as num?)?.toInt() ?? 0;
-      allStoryCount = postsCount + externalsCount;
+      allStoryCount = postsChunk.count + externalsChunk.count;
     }
 
     final jsonResponseFromGCP = await _helper.getByCacheAndAutoCache(
@@ -386,6 +260,187 @@ query FetchCategoryStoryList(
     }
 
     return newsList;
+  }
+
+  Future<_CategoryChunk> _fetchCategoryPosts(
+    String slug, {
+    required int take,
+    required bool withCount,
+  }) async {
+    const String queryString = """
+query FetchCategoryPosts(
+  \$slug: String!,
+  \$take: Int!,
+  \$withCount: Boolean!
+) {
+  posts(
+    where: {
+      state: { equals: "published" }
+      style: {
+        notIn: ["wide", "projects", "script", "campaign", "readr"]
+      }
+      categories: {
+        some: {
+          slug: { equals: \$slug }
+        }
+      }
+    }
+    take: \$take
+    orderBy: [{ publishTime: desc }]
+  ) {
+    id
+    slug
+    name
+    style
+    publishTime
+    heroImage {
+      imageApiData
+    }
+    heroVideo {
+      coverPhoto {
+        imageApiData
+      }
+    }
+    categories: categoriesInInputOrder {
+      id
+      slug
+      name
+    }
+  }
+
+  postsCount(
+    where: {
+      state: { equals: "published" }
+      style: {
+        notIn: ["wide", "projects", "script", "campaign", "readr"]
+      }
+      categories: {
+        some: {
+          slug: { equals: \$slug }
+        }
+      }
+    }
+  ) @include(if: \$withCount)
+}
+""";
+
+    final GraphqlBody graphqlBody = GraphqlBody(
+      operationName: 'FetchCategoryPosts',
+      query: queryString,
+      variables: {"slug": slug, "take": take, "withCount": withCount},
+    );
+
+    final jsonResponse = await _helper.postByUrl(
+      Environment().config.graphqlApi,
+      jsonEncode(graphqlBody.toJson()),
+      headers: {"Content-Type": "application/json"},
+    );
+
+    final List<dynamic> postJsonList =
+        (jsonResponse['data']?['posts'] as List?) ?? [];
+
+    return _CategoryChunk(
+      items: postJsonList.map((post) => StoryListItem.fromJson(post)).toList(),
+      count: (jsonResponse['data']?['postsCount'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  Future<_CategoryChunk> _fetchCategoryExternals(
+    String slug, {
+    required int take,
+    required bool withCount,
+  }) async {
+    const String queryString = """
+query FetchCategoryExternals(
+  \$slug: String!,
+  \$take: Int!,
+  \$withCount: Boolean!
+) {
+  externals(
+    where: {
+      state: { equals: "published" }
+      categories: {
+        some: {
+          slug: { equals: \$slug }
+        }
+      }
+    }
+    take: \$take
+    orderBy: [{ publishTime: desc }]
+  ) {
+    id
+    slug
+    name
+    subtitle
+    state
+    partner {
+      id
+      name
+      slug
+    }
+    publishTime
+    byline
+    thumbnail
+    heroCaption
+    brief_original
+    content_original
+    brief
+    content
+    tags {
+      id
+      name
+      slug
+    }
+    categories: categoriesInInputOrder {
+      id
+      name
+      slug
+    }
+    source
+    updatedAt
+    createdAt
+  }
+
+  externalsCount(
+    where: {
+      state: { equals: "published" }
+      categories: {
+        some: {
+          slug: { equals: \$slug }
+        }
+      }
+    }
+  ) @include(if: \$withCount)
+}
+""";
+
+    try {
+      final GraphqlBody graphqlBody = GraphqlBody(
+        operationName: 'FetchCategoryExternals',
+        query: queryString,
+        variables: {"slug": slug, "take": take, "withCount": withCount},
+      );
+
+      final jsonResponse = await _helper.postByUrl(
+        Environment().config.graphqlApi,
+        jsonEncode(graphqlBody.toJson()),
+        headers: {"Content-Type": "application/json"},
+      );
+
+      final List<dynamic> externalJsonList =
+          (jsonResponse['data']?['externals'] as List?) ?? [];
+
+      return _CategoryChunk(
+        items:
+            externalJsonList
+                .map((external) => StoryListItem.fromJson(external))
+                .toList(),
+        count: (jsonResponse['data']?['externalsCount'] as num?)?.toInt() ?? 0,
+      );
+    } catch (e) {
+      print('Fetch category externals failed for slug=$slug: $e');
+      return const _CategoryChunk.empty();
+    }
   }
 
   List<StoryListItem> _mergeSorted(Iterable<StoryListItem> items) {
@@ -497,4 +552,13 @@ query FetchCategoryStoryList(
 
     return storyListItemList;
   }
+}
+
+class _CategoryChunk {
+  final List<StoryListItem> items;
+  final int count;
+
+  const _CategoryChunk({required this.items, required this.count});
+
+  const _CategoryChunk.empty() : items = const [], count = 0;
 }


### PR DESCRIPTION
## Summary
- Split category-tab fetching into separate posts and externals GraphQL calls so an external-side failure no longer blanks the whole category tab.
- Fix category pagination sizing after merging posts and externals, so load-more appends the next page instead of growing the request window incorrectly.
- Mark External list items with external link type and pass it from category list cards into StoryPage.

## Prod checks
- fin: posts 20 / postsCount 4708, externals 17 / externalsCount 17, first external category = 鏡報.
- sport: posts 20 / postsCount 2189, externals 14 / externalsCount 14, first external category = 鏡報.

## Verification
- flutter analyze --no-fatal-warnings lib/services/tabStoryListService.dart lib/models/storyListItem.dart lib/pages/section/news/shared/news_story_first_item.dart lib/pages/section/news/shared/news_story_list_item.dart lib/controller/news_story_list_controller.dart
- git diff --check
