### PR TITLE
Fix FCM notification deep links

### DIFF
--- a/lib/helpers/firebaseMessagingHelper.dart
+++ b/lib/helpers/firebaseMessagingHelper.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
-import 'package:get/get.dart';
-import 'package:tv/pages/story_page.dart';
+import 'package:tv/helpers/notification_deep_link_parser.dart';
 
 /// Background message handler.
 ///
@@ -27,6 +26,11 @@ class FirebaseMessagingHelper {
   /// 直接 `Get.to(...)` 會 silent fail。因此把要導頁的 slug 暫存起來，
   /// 等 HomePage 掛載時再透過 [consumePendingStorySlug] 取出。
   static String? _pendingStorySlug;
+  static final StreamController<String> _storySlugController =
+      StreamController<String>.broadcast();
+  static bool _listenersRegistered = false;
+
+  static Stream<String> get storySlugStream => _storySlugController.stream;
 
   /// 取出並清空暫存的 deep link slug。連續呼叫只會成功一次。
   static String? consumePendingStorySlug() {
@@ -35,7 +39,24 @@ class FirebaseMessagingHelper {
     return slug;
   }
 
+  static void _queueStoryDeepLink(
+    Map<String, dynamic> data, {
+    required String source,
+  }) {
+    final slug = NotificationDeepLinkParser.extractStorySlug(data);
+    if (slug == null || slug.isEmpty) {
+      debugPrint('[fcm] $source has no story slug: $data');
+      return;
+    }
+
+    _pendingStorySlug = slug;
+    _storySlugController.add(slug);
+    debugPrint('[fcm] Queued story deep link from $source: $slug');
+  }
+
   Future<void> configFirebaseMessaging() async {
+    _registerMessageListeners();
+
     debugPrint('[fcm] Requesting notification permission');
     try {
       final NotificationSettings settings = await _firebaseMessaging
@@ -50,57 +71,63 @@ class FirebaseMessagingHelper {
           )
           .timeout(const Duration(seconds: 5));
       debugPrint(
-          '[fcm] User granted permission: ${settings.authorizationStatus}');
+        '[fcm] User granted permission: ${settings.authorizationStatus}',
+      );
     } on TimeoutException {
       debugPrint('[fcm] requestPermission timed out, continuing app launch');
     } catch (e) {
       debugPrint('[fcm] requestPermission failed: $e');
     }
 
-    // initial message: 由 cold-start 通知點擊觸發
-    RemoteMessage? initialMessage;
-    try {
-      debugPrint('[fcm] Waiting for initial message');
-      initialMessage = await _firebaseMessaging
-          .getInitialMessage()
-          .timeout(const Duration(seconds: 3), onTimeout: () {
-        debugPrint('[fcm] getInitialMessage timed out, continuing app launch');
-        return null;
-      });
-      debugPrint('[fcm] Initial message resolved: ${initialMessage?.messageId}');
-    } catch (e) {
-      debugPrint('[fcm] getInitialMessage failed: $e');
-    }
+    await _handleInitialMessage();
+  }
 
-    final initialMessageData = initialMessage?.data;
-    if (initialMessageData != null &&
-        initialMessageData.containsKey('news_story_slug')) {
-      // 不直接 Get.to：此時可能還在 ConfigPage，Navigator 還沒就緒。
-      // 暫存 slug，由 HomePage 掛載後 (consumePendingStorySlug) 觸發導頁。
-      _pendingStorySlug = initialMessageData['news_story_slug']?.toString();
-      debugPrint('[fcm] Cached pending story slug: $_pendingStorySlug');
-    }
+  void _registerMessageListeners() {
+    if (_listenersRegistered) return;
+    _listenersRegistered = true;
 
     // 前景訊息（App 開著時收到）
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
-      debugPrint('[fcm] onMessage received: ${message.messageId}, '
-          'data=${message.data}, notification=${message.notification?.title}');
+      debugPrint(
+        '[fcm] onMessage received: ${message.messageId}, '
+        'data=${message.data}, notification=${message.notification?.title}',
+      );
       // 預設 iOS 前景不會自動顯示 banner；若日後要做 in-app 提示，可在此擴充。
     });
     debugPrint('[fcm] Registered onMessage listener');
 
     // 點擊背景通知（App 在背景被通知喚醒並開啟）
     FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
-      debugPrint('[fcm] onMessageOpenedApp: ${message.messageId}');
-      final slug = message.data['news_story_slug']?.toString();
-      if (slug != null && slug.isNotEmpty) {
-        Get.to(
-          () => StoryPage(slug: slug),
-          preventDuplicates: false,
-        );
-      }
+      debugPrint(
+        '[fcm] onMessageOpenedApp: ${message.messageId}, '
+        'data=${message.data}',
+      );
+      _queueStoryDeepLink(message.data, source: 'onMessageOpenedApp');
     });
     debugPrint('[fcm] Registered onMessageOpenedApp listener');
+  }
+
+  Future<void> _handleInitialMessage() async {
+    // initial message: 由 cold-start 通知點擊觸發。
+    // configFirebaseMessaging 是 fire-and-forget，不會阻塞首頁；這裡不再用短 timeout
+    // 丟掉 late initialMessage，避免 App 冷啟動時只回首頁。
+    RemoteMessage? initialMessage;
+    try {
+      debugPrint('[fcm] Waiting for initial message');
+      initialMessage = await _firebaseMessaging.getInitialMessage();
+      debugPrint(
+        '[fcm] Initial message resolved: ${initialMessage?.messageId}',
+      );
+    } catch (e) {
+      debugPrint('[fcm] getInitialMessage failed: $e');
+    }
+
+    final initialMessageData = initialMessage?.data;
+    if (initialMessageData != null) {
+      // 不直接 Get.to：此時可能還在 ConfigPage，Navigator 還沒就緒。
+      // 暫存 slug，由 HomePage 掛載後 (consumePendingStorySlug) 觸發導頁。
+      _queueStoryDeepLink(initialMessageData, source: 'initialMessage');
+    }
   }
 
   void subscribeToTopic(String topic) {

--- a/lib/helpers/notification_deep_link_parser.dart
+++ b/lib/helpers/notification_deep_link_parser.dart
@@ -1,0 +1,147 @@
+import 'dart:convert';
+
+class NotificationDeepLinkParser {
+  static const List<String> _slugKeys = [
+    'news_story_slug',
+    'newsStorySlug',
+    'story_slug',
+    'storySlug',
+    'post_slug',
+    'postSlug',
+    'article_slug',
+    'articleSlug',
+    'slug',
+  ];
+
+  static const List<String> _urlKeys = [
+    'news_story_url',
+    'newsStoryUrl',
+    'story_url',
+    'storyUrl',
+    'article_url',
+    'articleUrl',
+    'deeplink',
+    'deep_link',
+    'deepLink',
+    'url',
+    'link',
+  ];
+
+  static String? extractStorySlug(Map<String, dynamic> data) {
+    for (final key in _slugKeys) {
+      final slug = _extractSlugFromValue(data[key], allowRawSlug: true);
+      if (slug != null) return slug;
+    }
+
+    for (final key in _urlKeys) {
+      final slug = _extractSlugFromValue(data[key], allowRawSlug: false);
+      if (slug != null) return slug;
+    }
+
+    for (final value in data.values) {
+      final slug = _extractSlugFromValue(value, allowRawSlug: false);
+      if (slug != null) return slug;
+    }
+
+    return null;
+  }
+
+  static String? _extractSlugFromValue(
+    Object? value, {
+    required bool allowRawSlug,
+  }) {
+    if (value == null) return null;
+
+    if (value is Map) {
+      return extractStorySlug(Map<String, dynamic>.from(value));
+    }
+
+    if (value is Iterable) {
+      for (final item in value) {
+        final slug = _extractSlugFromValue(item, allowRawSlug: allowRawSlug);
+        if (slug != null) return slug;
+      }
+      return null;
+    }
+
+    final raw = value.toString().trim();
+    if (raw.isEmpty) return null;
+
+    final decodedPayloadSlug = _extractSlugFromJsonPayload(raw);
+    if (decodedPayloadSlug != null) return decodedPayloadSlug;
+
+    final urlSlug = _extractSlugFromUrlLikeValue(raw);
+    if (urlSlug != null) return urlSlug;
+
+    if (allowRawSlug && _looksLikeSlug(raw)) {
+      return _cleanSlug(raw);
+    }
+
+    return null;
+  }
+
+  static String? _extractSlugFromJsonPayload(String raw) {
+    final startsLikeJson = raw.startsWith('{') || raw.startsWith('[');
+    if (!startsLikeJson) return null;
+
+    try {
+      final decoded = jsonDecode(raw);
+      return _extractSlugFromValue(decoded, allowRawSlug: false);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static String? _extractSlugFromUrlLikeValue(String raw) {
+    final uri = Uri.tryParse(raw);
+    if (uri == null) return null;
+
+    final segments =
+        uri.pathSegments
+            .map((segment) => segment.trim())
+            .where((segment) => segment.isNotEmpty)
+            .toList();
+
+    if (_isStoryPathHead(uri.host) && segments.isNotEmpty) {
+      return _cleanSlug(segments.last);
+    }
+
+    for (var i = 0; i < segments.length - 1; i++) {
+      if (_isStoryPathHead(segments[i])) {
+        return _cleanSlug(segments.last);
+      }
+    }
+
+    for (final key in _slugKeys) {
+      final value = uri.queryParameters[key];
+      if (value != null && value.trim().isNotEmpty) {
+        return _cleanSlug(value);
+      }
+    }
+
+    return null;
+  }
+
+  static bool _isStoryPathHead(String value) {
+    final normalized = value.trim().toLowerCase();
+    return normalized == 'story' || normalized == 'external';
+  }
+
+  static bool _looksLikeSlug(String raw) {
+    if (raw.contains(RegExp(r'\s'))) return false;
+    if (raw.contains('://')) return false;
+    if (raw.startsWith('{') || raw.startsWith('[')) return false;
+    return !raw.contains('/');
+  }
+
+  static String? _cleanSlug(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return null;
+
+    final withoutQuery = trimmed.split('?').first.split('#').first;
+    final decoded = Uri.decodeComponent(withoutQuery).trim();
+    if (decoded.isEmpty) return null;
+
+    return decoded;
+  }
+}

--- a/lib/initialApp.dart
+++ b/lib/initialApp.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tv/bindings/initial_app_binding.dart';
@@ -19,26 +21,42 @@ class InitialApp extends StatefulWidget {
 
 class _InitialAppState extends State<InitialApp> {
   late final InitialAppController controller;
-  bool _deepLinkHandled = false;
+  StreamSubscription<String>? _storyDeepLinkSubscription;
+  bool _pendingDeepLinkCallbackScheduled = false;
 
   @override
   void initState() {
     super.initState();
     InitialAppBinding().dependencies();
     controller = Get.find<InitialAppController>();
+    _storyDeepLinkSubscription = FirebaseMessagingHelper.storySlugStream.listen(
+      (_) {
+        _schedulePendingDeepLinkHandling();
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _storyDeepLinkSubscription?.cancel();
+    super.dispose();
   }
 
   /// 在 HomePage 掛載後執行：消化 cold-start 通知帶過來的 deep link slug。
-  /// 只會成功一次：[FirebaseMessagingHelper.consumePendingStorySlug] 取出後即清空，
-  /// 同時 `_deepLinkHandled` 保證 Obx rebuild 也不會重複 push。
-  void _handlePendingDeepLink() {
-    if (_deepLinkHandled) return;
-    _deepLinkHandled = true;
+  /// [FirebaseMessagingHelper.consumePendingStorySlug] 取出後即清空；
+  /// 若 FCM initialMessage 比 HomePage 晚回來，stream listener 會再次排程。
+  void _schedulePendingDeepLinkHandling() {
+    if (_pendingDeepLinkCallbackScheduled) return;
+    _pendingDeepLinkCallbackScheduled = true;
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      _pendingDeepLinkCallbackScheduled = false;
+      if (!mounted || !controller.isConfigReady.value) return;
+
       final slug = FirebaseMessagingHelper.consumePendingStorySlug();
       if (slug != null && slug.isNotEmpty) {
         debugPrint('[initial-app] Navigating to pending story: $slug');
-        Get.to(() => StoryPage(slug: slug));
+        Get.to(() => StoryPage(slug: slug), preventDuplicates: false);
       }
     });
   }
@@ -56,15 +74,13 @@ class _InitialAppState extends State<InitialApp> {
         debugPrint(
           '[initial-app] Config ready, showing HomePage with min version ${controller.minAppVersion.value}',
         );
-        _handlePendingDeepLink();
+        _schedulePendingDeepLinkHandling();
         return UpgradeAlert(
           upgrader: Upgrader(
             minAppVersion: controller.minAppVersion.value,
             messages: UpdateMessages(),
           ),
-          child: HomePage(
-            appVersion: controller.appVersion.value,
-          ),
+          child: HomePage(appVersion: controller.appVersion.value),
         );
       }
 
@@ -81,23 +97,16 @@ class _InitialAppState extends State<InitialApp> {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            Image.asset(
-              logoPng,
-              scale: 4.0,
+            Image.asset(logoPng, scale: 4.0),
+            const SizedBox(height: 20),
+            Text(
+              '載入失敗',
+              style: const TextStyle(color: Colors.white, fontSize: 17),
             ),
-            const SizedBox(
-              height: 20,
+            Text(
+              '請檢查網路連線後再重新開啟',
+              style: const TextStyle(color: Colors.white, fontSize: 17),
             ),
-            Text('載入失敗',
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 17,
-                )),
-            Text('請檢查網路連線後再重新開啟',
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 17,
-                )),
           ],
         ),
       ),

--- a/test/helpers/notification_deep_link_parser_test.dart
+++ b/test/helpers/notification_deep_link_parser_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tv/helpers/notification_deep_link_parser.dart';
+
+void main() {
+  group('NotificationDeepLinkParser.extractStorySlug', () {
+    test('extracts the legacy news story slug key', () {
+      final slug = NotificationDeepLinkParser.extractStorySlug({
+        'news_story_slug': 'sample-story',
+      });
+
+      expect(slug, 'sample-story');
+    });
+
+    test('extracts common camelCase slug keys', () {
+      final slug = NotificationDeepLinkParser.extractStorySlug({
+        'storySlug': 'camel-case-story',
+      });
+
+      expect(slug, 'camel-case-story');
+    });
+
+    test('extracts slug from a website story URL', () {
+      final slug = NotificationDeepLinkParser.extractStorySlug({
+        'url': 'https://www.mnews.tw/story/article-slug?utm_source=fcm',
+      });
+
+      expect(slug, 'article-slug');
+    });
+
+    test('extracts slug from an app deep link', () {
+      final slug = NotificationDeepLinkParser.extractStorySlug({
+        'deepLink': 'mnews://story/deep-link-story',
+      });
+
+      expect(slug, 'deep-link-story');
+    });
+
+    test('extracts slug from a JSON payload string', () {
+      final slug = NotificationDeepLinkParser.extractStorySlug({
+        'payload': '{"story_url":"https://www.mnews.tw/story/json-story"}',
+      });
+
+      expect(slug, 'json-story');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- fix FCM notification tap routing so cold-start messages are queued until the app is ready to navigate
- centralize notification payload parsing and support story slugs from legacy keys, common slug keys, URLs, deep links, and JSON payload strings
- add focused parser tests for the supported notification payload shapes

## Root Cause

Firebase Console is still sending `news_story_slug`, so the payload format itself was not the current blocker. The app could still land on the homepage because FCM setup is fire-and-forget and the old cold-start flow only consumed a pending slug once. If `getInitialMessage()` resolved after HomePage had already checked, no later navigation was triggered.

## Validation

- `flutter analyze lib/helpers/firebaseMessagingHelper.dart lib/helpers/notification_deep_link_parser.dart lib/initialApp.dart test/helpers/notification_deep_link_parser_test.dart`
- `flutter test test/helpers/notification_deep_link_parser_test.dart`
